### PR TITLE
Add encoding parameter to logfile

### DIFF
--- a/ChangeIntunePrimaryUser/ChangeIntunePrimaryUser.ps1
+++ b/ChangeIntunePrimaryUser/ChangeIntunePrimaryUser.ps1
@@ -12,7 +12,7 @@ $tenantId = '<Your tenantID>'
 
 $Logfile = "$PSScriptRoot\ChangePrimaryUser.log"
 function WriteLog($LogText) { 
-    Add-Content -path $LogFile -value "$((Get-Date).ToString()) $LogText" -Force -ErrorAction SilentlyContinue
+    Add-Content -path $LogFile -value "$((Get-Date).ToString()) $LogText" -Force -ErrorAction SilentlyContinue -Encoding UTF8
     Write-Verbose $LogText
 }
 function Get-AccessToken {


### PR DESCRIPTION
Add UTF8 encoding parameter to logfile for correct support of characters with diacritical marks, such as “Fabián” when logging the client display name.